### PR TITLE
Updating the graphite plugin cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 Chef-Bareos Cookbook
 --------------------
 
+3.0.4
+-----
+#### Ian Smith
+  * Updating the cronjob resource to only be included if user specifies a desire to enable a cronjob, defaults to off
+
 3.0.3
 -----
 #### Ian Smith

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A new plugin that will send statistics to a graphite server which can then be us
 | ['bareos']['plugins']['graphite']['graphite_port'] | '2003' | Default graphite communication port
 | ['bareos']['plugins']['graphite']['graphite_data_prefix'] | 'bareos.' | Default prefix for graphite data
 | ['bareos']['plugins']['graphite']['graphite_plugin_src_url'] | See attributes file | Default URL to the plugin
+| ['bareos']['plugins']['graphite']['cron_job'] | nil | Activates a general minutely cronjob if defined other than nil
 
 ## Recipes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs/Configures BAREOS - Backup Archiving REcovery Open S
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url        'https://github.com/sitle/chef-bareos/issues'
 source_url        'https://github.com/sitle/chef-bareos.git'
-version           '3.0.3'
+version           '3.0.4'
 
 %w( centos redhat ).each do |os|
   supports os, '>= 6.0'

--- a/recipes/graphite_plugin.rb
+++ b/recipes/graphite_plugin.rb
@@ -48,6 +48,5 @@ cron 'bareos_graphite_poller' do
     -c #{node['bareos']['plugins']['graphite']['config_path']}/graphite-poller.conf
   EOH
   mailto node['bareos']['plugins']['graphite']['mail_to']
-  user 'bareos'
-  minute '5'
+  only_if node['bareos']['plugins']['graphite']['cron_job']
 end


### PR DESCRIPTION
After some thought I have decided it is better to leave as many defaults so it will run as root crontab and run minutely still.. It is extra data but if you have running jobs that you want to track stats for, this will add more data to analyze. I am also adding a new attribute that will have to be defined in order for the cronjob to be turned on. This allows some additional flexibility in case a user doesn't like my cron settings. Also avoids temptation to do a rewind someplace..
